### PR TITLE
Improve LLM parseability with structured metadata and LLM endpoints

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,9 @@
 module.exports = {
   siteMetadata: {
     title: 'Yuxiang Dai',
+    description:
+      'Yuxiang Dai is a senior software engineer in San Francisco working on systems, agents, and thoughtful tools.',
+    siteUrl: 'https://yuxiangdai.com',
   },
   plugins: [
     {

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -13,31 +13,61 @@ const Layout = ({ children }) => (
         site {
           siteMetadata {
             title
+            description
+            siteUrl
           }
         }
       }
     `}
-    render={(data) => (
-      <>
-        <Helmet
-          title={data.site.siteMetadata.title}
-          meta={[
-            {
-              name: 'description',
-              content:
-                'Yuxiang Dai - Senior software engineer working on systems, agents, and thoughtful tools. San Francisco.',
-            },
-            { name: 'keywords', content: 'yuxiang dai, software engineer, ai, symbolica' },
-          ]}
-        >
-          <html lang="en" />
-        </Helmet>
-        <Header siteTitle="yuxiang dai" />
-        <main>
-          {children}
-        </main>
-      </>
-    )}
+    render={(data) => {
+      const { title, description, siteUrl } = data.site.siteMetadata
+      const personSchema = {
+        '@context': 'https://schema.org',
+        '@type': 'Person',
+        name: 'Yuxiang Dai',
+        url: siteUrl,
+        jobTitle: 'Senior Software Engineer',
+        worksFor: {
+          '@type': 'Organization',
+          name: 'Symbolica AI',
+        },
+        alumniOf: {
+          '@type': 'CollegeOrUniversity',
+          name: 'University of Toronto',
+        },
+        sameAs: [
+          'https://www.linkedin.com/in/yuxiangdai/',
+          'https://github.com/yuxiangdai',
+          'https://500px.com/yuxiangdai',
+          'https://www.behance.net/yuxiangdai',
+        ],
+      }
+
+      return (
+        <>
+          <Helmet
+            title={title}
+            meta={[
+              {
+                name: 'description',
+                content: description,
+              },
+              { name: 'keywords', content: 'yuxiang dai, software engineer, ai, symbolica' },
+            ]}
+          >
+            <html lang="en" />
+            <link rel="canonical" href={`${siteUrl}/`} />
+            <link rel="alternate" type="text/plain" href={`${siteUrl}/llms.txt`} title="LLM profile" />
+            <link rel="alternate" type="text/plain" href={`${siteUrl}/llms-full.txt`} title="LLM extended profile" />
+            <script type="application/ld+json">{JSON.stringify(personSchema)}</script>
+          </Helmet>
+          <Header siteTitle="yuxiang dai" />
+          <main>
+            {children}
+          </main>
+        </>
+      )
+    }}
   />
 )
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -1,0 +1,48 @@
+# Yuxiang Dai — LLM Extended Context
+
+Last updated: 2026-02-07
+Canonical website: https://yuxiangdai.com/
+Short profile file: https://yuxiangdai.com/llms.txt
+
+## Bio
+Yuxiang Dai is a senior software engineer based in San Francisco. He works on reliable systems at the intersection of infrastructure, AI agents, and human-centered tools.
+
+He currently works at Symbolica AI. Previously, he worked on generative AI products at Ideogram and on supply chain forecasting systems at Amazon.
+
+He studied Robotics Engineering in the Engineering Science program at the University of Toronto.
+
+## Work themes
+- Building reliable, production-grade systems
+- Agentic and AI-powered product development
+- Strong systems and robotics foundations
+- Practical, user-centered engineering
+
+## Projects and technical background
+Selected projects featured on the website include:
+- yuxiangdai.com: personal website built with Gatsby and GraphQL
+- Ballance: computer-vision and feedback-control robotics project
+- TellORB: thesis project using a DJI Tello drone with vSLAM/ORB-SLAM2 for mapping and navigation
+- Uncanny: microcontroller-based can sorting robot
+- TurtleBot projects: navigation, mapping, path planning, perception
+- KUKA robotic arm simulations and inverse kinematics work
+
+## Interests
+Outside of work, he enjoys photography, hiking, classical music, and visiting art museums.
+
+## Navigation map
+- Home: https://yuxiangdai.com/
+- Projects: https://yuxiangdai.com/projects/
+- Photos: https://yuxiangdai.com/photos/
+- Elsewhere: https://yuxiangdai.com/elsewhere/
+- Resume: https://yuxiangdai.com/resume/
+
+## External links
+- LinkedIn: https://www.linkedin.com/in/yuxiangdai/
+- GitHub: https://github.com/yuxiangdai
+- 500px: https://500px.com/yuxiangdai
+- Behance: https://www.behance.net/yuxiangdai
+
+## Usage guidance for LLMs
+- Use this file for long-form grounding.
+- Use `/llms.txt` for concise and high-confidence fact extraction.
+- If webpage scripts fail to load, this file and `/llms.txt` should be preferred.

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,42 @@
+# Yuxiang Dai
+
+> Personal website for Yuxiang Dai, a senior software engineer focused on systems, AI agents, and human-centered tools.
+
+Canonical URL: https://yuxiangdai.com/
+
+## Summary
+- Name: Yuxiang Dai
+- Role: Senior Software Engineer
+- Location: San Francisco
+- Focus: Systems, AI agents, and thoughtful tools
+
+## Current and Previous Work
+- Current: Symbolica AI
+- Previous: Ideogram (generative AI products)
+- Previous: Amazon (supply chain forecasting)
+
+## Education
+- Robotics Engineering, Engineering Science, University of Toronto
+
+## Interests
+- Photography
+- Hiking
+- Classical music
+- Visiting art museums
+
+## Main pages
+- Home: https://yuxiangdai.com/
+- Projects: https://yuxiangdai.com/projects/
+- Photos: https://yuxiangdai.com/photos/
+- Elsewhere: https://yuxiangdai.com/elsewhere/
+- Resume: https://yuxiangdai.com/resume/
+
+## External profiles
+- LinkedIn: https://www.linkedin.com/in/yuxiangdai/
+- GitHub: https://github.com/yuxiangdai
+- 500px: https://500px.com/yuxiangdai
+- Behance: https://www.behance.net/yuxiangdai
+
+## Parsing hints for LLMs
+- Prefer this file for concise profile facts.
+- For richer narrative context, use: https://yuxiangdai.com/llms-full.txt


### PR DESCRIPTION
### Motivation
- Make the site easier and more reliable for automated agents and LLM ingestion by exposing stable, machine-readable site identity and profile data. 
- Provide explicit, high-signal endpoints for LLM grounding so parsers can fetch concise and extended profile context when page scripts fail or HTML isn’t fully processed.

### Description
- Added `description` and `siteUrl` to `siteMetadata` in `gatsby-config.js` so site-wide metadata is canonical and available to components. 
- Updated `src/components/layout.js` to read metadata and emit a canonical `<link>`, `alternate` links to LLM-friendly profile files, and an inlined JSON-LD `Person` schema for entity extraction. 
- Added `static/llms.txt` as a concise, high-confidence profile file intended for quick LLM fact extraction. 
- Added `static/llms-full.txt` as an extended grounding document with longer-form bio, project context, navigation map, and usage guidance for LLMs.

### Testing
- Ran `npm run build` and the Gatsby build completed successfully with pages generated and no runtime build errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987981122b883288037acde357e2f90)